### PR TITLE
Fix string polyfills

### DIFF
--- a/lib/strings.js
+++ b/lib/strings.js
@@ -11,7 +11,7 @@ function format(s, args){
         if (idx > -1){
             result += s.substr(lastIdx, idx-lastIdx);
             idx = idx+START.length;
-            
+
             endIdx = s.indexOf(END, idx);
             if (endIdx === -1){
                 throw new Error('Invalid arg format. Missing "' + END + '".');
@@ -29,15 +29,29 @@ function format(s, args){
     return result;
 }
 
-String.prototype.endsWith = function endsWith(endStr){
-    if (this === null || endStr === null){ return false; }
-    return (this.indexOf(endStr) + endStr.length) === this.length;
-};
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/endsWith
+if (typeof String.prototype.endsWith !== 'function') {
+  String.prototype.endsWith = function(searchString, position) {
+    var subjectString = this.toString();
+    if (typeof position !== 'number' ||
+      !isFinite(position) ||
+      Math.floor(position) !== position ||
+      position > subjectString.length) {
+      position = subjectString.length;
+    }
+    position -= searchString.length;
+    var lastIndex = subjectString.lastIndexOf(searchString, position);
+    return lastIndex !== -1 && lastIndex === position;
+  };
+}
 
-String.prototype.startsWith = function startsWith(startStr){
-    if (this === null || startStr === null){ return false; }
-    return (this.indexOf(startStr) === 0);
-};
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/startsWith
+if (typeof String.prototype.startsWith !== 'function') {
+  String.prototype.startsWith = function(searchString, position) {
+    position = position || 0;
+    return this.substr(position, searchString.length) === searchString;
+  };
+}
 
 module.exports = {
     format: format

--- a/lib/strings.js
+++ b/lib/strings.js
@@ -39,7 +39,7 @@ if (typeof String.prototype.endsWith !== 'function') {
       position > subjectString.length) {
       position = subjectString.length;
     }
-    position -= searchString.length;
+    position -= (searchString && searchString.length) || 0;
     var lastIndex = subjectString.lastIndexOf(searchString, position);
     return lastIndex !== -1 && lastIndex === position;
   };
@@ -49,7 +49,7 @@ if (typeof String.prototype.endsWith !== 'function') {
 if (typeof String.prototype.startsWith !== 'function') {
   String.prototype.startsWith = function(searchString, position) {
     position = position || 0;
-    return this.substr(position, searchString.length) === searchString;
+    return this.substr(position, (searchString && searchString.length) || 0) === searchString;
   };
 }
 

--- a/test/unit/lib/strings_tests.js
+++ b/test/unit/lib/strings_tests.js
@@ -8,13 +8,13 @@ describe("strings", function() {
         assert.isObject(strings);
         done();
     });
-    
+
     it("should parse string", function(done) {
         var o = strings.format('Hello {{name}}{{not-found}}', { name: 'World' });
         assert.equal(o, 'Hello World', "should match parsed result");
         done();
     });
-    
+
     it("should throw error on invalid placeholder", function(done) {
         try{
             var o = strings.format('Hello {{name', { name: 'World' });
@@ -25,28 +25,40 @@ describe("strings", function() {
             done();
         }
     });
-    
+
     it("should end with", function(done) {
         var flag = 'Hello World'.endsWith('World');
         assert.isTrue(flag, "should find endsWith");
         done();
     });
-    
+
     it("should not find null using endsWith", function(done) {
         var flag = 'Hello World'.endsWith(null);
         assert.isFalse(flag, "should not find null");
         done();
     });
-    
+
+    it("should find empty using endsWith", function(done) {
+        var flag = 'Hello World'.endsWith('');
+        assert.isTrue(flag, "should find empty");
+        done();
+    });
+
     it("should start with", function(done) {
         var flag = 'Hello World'.startsWith('Hello');
         assert.isTrue(flag, "should find startStr");
         done();
     });
-    
+
     it("should not find null using startsWith", function(done) {
         var flag = 'Hello World'.startsWith(null);
         assert.isFalse(flag, "should not find null");
+        done();
+    });
+
+    it("should find empty using startsWith", function(done) {
+        var flag = 'Hello World'.startsWith('');
+        assert.isTrue(flag, "should find empty");
         done();
     });
 });


### PR DESCRIPTION
The native `startsWith` and `endsWith` were being overridden with a method with a different signature. Fixed the polyfill for Node 0.10/0.12 to have the same signature. Pulled the polyfill code from Mozilla.

Fixes https://github.com/azweb76/node-x-util/issues/2